### PR TITLE
Remove default Safari styling from submit button in search form

### DIFF
--- a/priv/styles.css
+++ b/priv/styles.css
@@ -101,6 +101,7 @@ h1, h2, h3, h4, h5, h6 {
   height: 30px;
   padding: 0 var(--gap-s);
   margin-left: 1px;
+  -webkit-appearance: none;
 }
 
 .site-footer {


### PR DESCRIPTION
Closes #6.

The result (tested in iOS 16.3.1) is the following: 

- Before
![IMG_2792](https://user-images.githubusercontent.com/20598369/235446159-ea2724d5-40f1-4fd4-b319-e19690331d5e.PNG)

- After
![IMG_2793](https://user-images.githubusercontent.com/20598369/235446189-278bed65-85a3-42f6-a8fa-44f70d4fa18f.PNG)
