### PR TITLE
Focus the search input when the "/" key is pressed

### DIFF
--- a/priv/main.js
+++ b/priv/main.js
@@ -1,6 +1,6 @@
 document.addEventListener("keypress", (event) => {
   if (event.key === "/") {
-    const searchInput = document.getElementById("search-input");
+    const searchInput = document.querySelector("[data-search-input]");
     if (searchInput) {
       const isAlreadyFocused = document.activeElement === searchInput;
       if (!isAlreadyFocused) {

--- a/priv/main.js
+++ b/priv/main.js
@@ -1,12 +1,10 @@
-"use strict";
-
 document.addEventListener("keypress", (event) => {
-  if (event.key === "s" || event.key === "S") {
+  if (event.key === "/") {
     const searchInput = document.getElementById("search-input");
     if (searchInput) {
       const isAlreadyFocused = document.activeElement === searchInput;
       if (!isAlreadyFocused) {
-        // Prevent the "S" from being added to the search when we focus it.
+        // Prevent the "/" from being added to the search when we focus it.
         event.preventDefault();
 
         searchInput.focus();

--- a/priv/search-input.js
+++ b/priv/search-input.js
@@ -1,0 +1,16 @@
+"use strict";
+
+document.addEventListener("keypress", (event) => {
+  if (event.key === "s" || event.key === "S") {
+    const searchInput = document.getElementById("search-input");
+    if (searchInput) {
+      const isAlreadyFocused = document.activeElement === searchInput;
+      if (!isAlreadyFocused) {
+        // Prevent the "S" from being added to the search when we focus it.
+        event.preventDefault();
+
+        searchInput.focus();
+      }
+    }
+  }
+});

--- a/priv/styles.css
+++ b/priv/styles.css
@@ -95,13 +95,18 @@ h1, h2, h3, h4, h5, h6 {
   border-radius: 100px 0 0 100px;
 }
 
+@media screen and (min-width: 60em) {
+  .search-form input[type=search] {
+    min-width: 300px;
+  }
+}
+
 .search-form input[type=submit] {
   background: var(--color-white);
   border: none;
   border-radius: 0 100px 100px 0;
   height: 30px;
   padding: 0 var(--gap-s);
-  margin-left: 1px;
   -webkit-appearance: none;
 }
 

--- a/src/packages/web.gleam
+++ b/src/packages/web.gleam
@@ -29,7 +29,7 @@ pub fn handle_request(context: Context) -> Response(BitBuilder) {
   case path {
     [] -> search(context)
     ["styles.css"] -> stylesheet()
-    ["search-input.js"] -> search_input_script()
+    ["main.js"] -> javascript()
     _ -> redirect(to: "/")
   }
 }
@@ -42,9 +42,9 @@ fn stylesheet() -> Response(BitBuilder) {
   |> response.set_body(bit_builder.from_bit_string(css))
 }
 
-fn search_input_script() -> Response(BitBuilder) {
+fn javascript() -> Response(BitBuilder) {
   let assert Ok(priv) = erlang_extra.priv_directory("packages")
-  let assert Ok(js) = file.read_bits(priv <> "/search-input.js")
+  let assert Ok(js) = file.read_bits(priv <> "/main.js")
   response.new(200)
   |> response.set_header(
     "content-type",

--- a/src/packages/web.gleam
+++ b/src/packages/web.gleam
@@ -29,6 +29,7 @@ pub fn handle_request(context: Context) -> Response(BitBuilder) {
   case path {
     [] -> search(context)
     ["styles.css"] -> stylesheet()
+    ["search-input.js"] -> search_input_script()
     _ -> redirect(to: "/")
   }
 }
@@ -39,6 +40,17 @@ fn stylesheet() -> Response(BitBuilder) {
   response.new(200)
   |> response.set_header("content-type", "text/css; charset=utf-8")
   |> response.set_body(bit_builder.from_bit_string(css))
+}
+
+fn search_input_script() -> Response(BitBuilder) {
+  let assert Ok(priv) = erlang_extra.priv_directory("packages")
+  let assert Ok(js) = file.read_bits(priv <> "/search-input.js")
+  response.new(200)
+  |> response.set_header(
+    "content-type",
+    "application/javascript; charset=utf-8",
+  )
+  |> response.set_body(bit_builder.from_bit_string(js))
 }
 
 fn search(context: Context) -> Response(BitBuilder) {

--- a/src/packages/web/page.gleam
+++ b/src/packages/web/page.gleam
@@ -43,7 +43,7 @@ fn search_form(search_term: String) -> Node(t) {
         attrs.name("search"),
         attrs.type_("search"),
         attrs.value(search_term),
-        attrs.placeholder("Search for packages (S to focus)"),
+        attrs.placeholder("Search for packages (/ to focus)"),
       ]),
       html.input([attrs.type_("submit"), attrs.value("🔎")]),
     ],
@@ -114,7 +114,7 @@ fn layout(content: Node(t)) -> Node(t) {
         ],
         [],
       ),
-      html.Element("script", [attrs.src("/search-input.js")], []),
+      html.Element("script", [attrs.type_("module"), attrs.src("/main.js")], []),
     ]),
     content,
     html.footer(

--- a/src/packages/web/page.gleam
+++ b/src/packages/web/page.gleam
@@ -39,7 +39,7 @@ fn search_form(search_term: String) -> Node(t) {
     [attrs.class("search-form"), attrs.Attr("method", "GET")],
     [
       html.input([
-        attrs.id("search-input"),
+        attrs.data("search-input", ""),
         attrs.name("search"),
         attrs.type_("search"),
         attrs.value(search_term),

--- a/src/packages/web/page.gleam
+++ b/src/packages/web/page.gleam
@@ -39,9 +39,11 @@ fn search_form(search_term: String) -> Node(t) {
     [attrs.class("search-form"), attrs.Attr("method", "GET")],
     [
       html.input([
+        attrs.id("search-input"),
         attrs.name("search"),
         attrs.type_("search"),
         attrs.value(search_term),
+        attrs.placeholder("Search for packages (S to focus)"),
       ]),
       html.input([attrs.type_("submit"), attrs.value("🔎")]),
     ],
@@ -112,6 +114,7 @@ fn layout(content: Node(t)) -> Node(t) {
         ],
         [],
       ),
+      html.Element("script", [attrs.src("/search-input.js")], []),
     ]),
     content,
     html.footer(


### PR DESCRIPTION
This PR adds support for focusing the search input when the <kbd>/</kbd> key is pressed.

I also added some placeholder text to the input with instructions.

Here's what it looks like on a medium-sized browser window:

<img width="1232" alt="Screenshot 2023-05-28 at 7 58 06 PM" src="https://github.com/gleam-lang/packages/assets/1486634/a1660242-6358-4de8-a914-496ca515ea57">

And on a smaller window:

<img width="798" alt="Screenshot 2023-05-28 at 7 58 10 PM" src="https://github.com/gleam-lang/packages/assets/1486634/0191040a-a458-42b6-8826-03f13d3bf72d">

This is similar to what is done on other package manager sites, like for Rust and PureScript:

<img width="1206" alt="Screenshot 2023-05-28 at 1 28 17 PM" src="https://github.com/gleam-lang/packages/assets/1486634/51e0035f-0dfc-49bd-bcc9-951f0e455fcf">

<img width="1206" alt="Screenshot 2023-05-28 at 1 28 29 PM" src="https://github.com/gleam-lang/packages/assets/1486634/2cecd28f-089f-43cf-bb95-68b0f8879345">
