### PR TITLE
Add documentation and repository links

### DIFF
--- a/priv/styles.css
+++ b/priv/styles.css
@@ -128,6 +128,10 @@ h1, h2, h3, h4, h5, h6 {
   margin-top: 0.3rem;
 }
 
+.package-links {
+  margin-top: var(--gap);
+}
+
 .package-list h2 {
   margin: 0 var(--gap) var(--gap-s) 0;
 }

--- a/priv/styles.css
+++ b/priv/styles.css
@@ -26,6 +26,7 @@
   --color-unexpected-aubergine: #584355;
 
   --font-size-normal: 18px;
+  --font-size-small: 14px;
 
   --content-width: 960px;
   --gap: 1rem;
@@ -137,8 +138,21 @@ h1, h2, h3, h4, h5, h6 {
   margin-top: var(--gap);
 }
 
+.package-links ul {
+  display: flex;
+  padding: 0;
+  list-style-type: none;
+}
+
+.package-links li {
+  margin: 0;
+}
+
 .package-links a {
   margin-right: var(--gap);
+  color: var(--color-unexpected-aubergine);
+  font-size: var(--font-size-small);
+  text-decoration: none;
 }
 
 .package-list h2 {

--- a/priv/styles.css
+++ b/priv/styles.css
@@ -137,6 +137,10 @@ h1, h2, h3, h4, h5, h6 {
   margin-top: var(--gap);
 }
 
+.package-links a {
+  margin-right: var(--gap);
+}
+
 .package-list h2 {
   margin: 0 var(--gap) var(--gap-s) 0;
 }

--- a/priv/styles.css
+++ b/priv/styles.css
@@ -134,6 +134,10 @@ h1, h2, h3, h4, h5, h6 {
   margin-top: 0.3rem;
 }
 
+.package-description {
+  margin-top: var(--gap);
+}
+
 .package-links {
   margin-top: var(--gap);
 }
@@ -157,8 +161,4 @@ h1, h2, h3, h4, h5, h6 {
 
 .package-list h2 {
   margin: 0 var(--gap) var(--gap-s) 0;
-}
-
-.package-list p {
-  margin: 0;
 }

--- a/sql/get_package.sql
+++ b/sql/get_package.sql
@@ -2,7 +2,7 @@ select
   name
 , description
 , docs_url
-, repository_url
+, links
 , inserted_in_hex_at
 , updated_in_hex_at
 from

--- a/sql/get_package.sql
+++ b/sql/get_package.sql
@@ -1,6 +1,7 @@
 select
   name
 , description
+, docs_url
 , inserted_in_hex_at
 , updated_in_hex_at
 from

--- a/sql/get_package.sql
+++ b/sql/get_package.sql
@@ -2,6 +2,7 @@ select
   name
 , description
 , docs_url
+, repository_url
 , inserted_in_hex_at
 , updated_in_hex_at
 from

--- a/sql/migrate_schema.sql
+++ b/sql/migrate_schema.sql
@@ -86,8 +86,7 @@ insert into hidden_packages values
 on conflict do nothing;
 
 alter table packages
-add column if not exists docs_url text,
-add column if not exists repository_url text;
+add column if not exists docs_url text;
 
 end
 $$;

--- a/sql/migrate_schema.sql
+++ b/sql/migrate_schema.sql
@@ -9,10 +9,10 @@ create table if not exists most_recent_hex_timestamp (
 , constraint most_recent_hex_timestamp_singleton check (id)
 );
 
--- Use the timestamp of the first ever Gleam package as the initial timestamp.
--- insert into most_recent_hex_timestamp
--- values (1635092380)
--- on conflict do nothing;
+Use the timestamp of the first ever Gleam package as the initial timestamp.
+insert into most_recent_hex_timestamp
+values (1635092380)
+on conflict do nothing;
 
 create table if not exists packages
 ( id serial primary key

--- a/sql/migrate_schema.sql
+++ b/sql/migrate_schema.sql
@@ -9,7 +9,7 @@ create table if not exists most_recent_hex_timestamp (
 , constraint most_recent_hex_timestamp_singleton check (id)
 );
 
-Use the timestamp of the first ever Gleam package as the initial timestamp.
+-- Use the timestamp of the first ever Gleam package as the initial timestamp.
 insert into most_recent_hex_timestamp
 values (1635092380)
 on conflict do nothing;

--- a/sql/migrate_schema.sql
+++ b/sql/migrate_schema.sql
@@ -10,9 +10,9 @@ create table if not exists most_recent_hex_timestamp (
 );
 
 -- Use the timestamp of the first ever Gleam package as the initial timestamp.
-insert into most_recent_hex_timestamp
-values (1635092380)
-on conflict do nothing;
+-- insert into most_recent_hex_timestamp
+-- values (1635092380)
+-- on conflict do nothing;
 
 create table if not exists packages
 ( id serial primary key

--- a/sql/migrate_schema.sql
+++ b/sql/migrate_schema.sql
@@ -85,5 +85,9 @@ insert into hidden_packages values
 , ('sequin')
 on conflict do nothing;
 
+alter table packages
+add column if not exists docs_url text,
+add column if not exists repository_url text;
+
 end
 $$;

--- a/sql/search_packages.sql
+++ b/sql/search_packages.sql
@@ -1,6 +1,7 @@
 select
   packages.name
 , description
+, docs_url
 , array_agg(latest_releases.version) as latest_releases
 , packages.updated_in_hex_at
 from

--- a/sql/search_packages.sql
+++ b/sql/search_packages.sql
@@ -2,6 +2,7 @@ select
   packages.name
 , description
 , docs_url
+, repository_url
 , array_agg(latest_releases.version) as latest_releases
 , packages.updated_in_hex_at
 from

--- a/sql/search_packages.sql
+++ b/sql/search_packages.sql
@@ -2,7 +2,7 @@ select
   packages.name
 , description
 , docs_url
-, repository_url
+, links
 , array_agg(latest_releases.version) as latest_releases
 , packages.updated_in_hex_at
 from

--- a/sql/upsert_package.sql
+++ b/sql/upsert_package.sql
@@ -3,7 +3,7 @@ insert into packages
   ( name
   , description
   , docs_url
-  , repository_url
+  , links
   , inserted_in_hex_at
   , updated_in_hex_at
   )
@@ -20,6 +20,6 @@ set
   updated_in_hex_at = excluded.updated_in_hex_at
 , description = excluded.description
 , docs_url = excluded.docs_url
-, repository_url = excluded.repository_url
+, links = excluded.links
 returning
   id

--- a/sql/upsert_package.sql
+++ b/sql/upsert_package.sql
@@ -3,6 +3,7 @@ insert into packages
   ( name
   , description
   , docs_url
+  , repository_url
   , inserted_in_hex_at
   , updated_in_hex_at
   )
@@ -12,11 +13,13 @@ values
   , $3
   , $4
   , $5
+  , $6
   )
 on conflict (name) do update
 set
   updated_in_hex_at = excluded.updated_in_hex_at
 , description = excluded.description
 , docs_url = excluded.docs_url
+, repository_url = excluded.repository_url
 returning
   id

--- a/sql/upsert_package.sql
+++ b/sql/upsert_package.sql
@@ -2,6 +2,7 @@
 insert into packages
   ( name
   , description
+  , docs_url
   , inserted_in_hex_at
   , updated_in_hex_at
   )
@@ -10,10 +11,12 @@ values
   , $2
   , $3
   , $4
+  , $5
   )
 on conflict (name) do update
 set
   updated_in_hex_at = excluded.updated_in_hex_at
 , description = excluded.description
+, docs_url = excluded.docs_url
 returning
   id

--- a/src/packages/generated/sql.gleam
+++ b/src/packages/generated/sql.gleam
@@ -278,8 +278,7 @@ insert into hidden_packages values
 on conflict do nothing;
 
 alter table packages
-add column if not exists docs_url text,
-add column if not exists repository_url text;
+add column if not exists docs_url text;
 
 end
 $$;

--- a/src/packages/generated/sql.gleam
+++ b/src/packages/generated/sql.gleam
@@ -96,6 +96,7 @@ pub fn get_package(
   name
 , description
 , docs_url
+, repository_url
 , inserted_in_hex_at
 , updated_in_hex_at
 from
@@ -133,6 +134,7 @@ pub fn search_packages(
   packages.name
 , description
 , docs_url
+, repository_url
 , array_agg(latest_releases.version) as latest_releases
 , packages.updated_in_hex_at
 from
@@ -316,6 +318,7 @@ insert into packages
   ( name
   , description
   , docs_url
+  , repository_url
   , inserted_in_hex_at
   , updated_in_hex_at
   )
@@ -325,12 +328,14 @@ values
   , $3
   , $4
   , $5
+  , $6
   )
 on conflict (name) do update
 set
   updated_in_hex_at = excluded.updated_in_hex_at
 , description = excluded.description
 , docs_url = excluded.docs_url
+, repository_url = excluded.repository_url
 returning
   id
 "

--- a/src/packages/generated/sql.gleam
+++ b/src/packages/generated/sql.gleam
@@ -206,11 +206,6 @@ create table if not exists most_recent_hex_timestamp (
 , constraint most_recent_hex_timestamp_singleton check (id)
 );
 
--- Use the timestamp of the first ever Gleam package as the initial timestamp.
--- insert into most_recent_hex_timestamp
--- values (1635092380)
--- on conflict do nothing;
-
 create table if not exists packages
 ( id serial primary key
 , name text not null unique

--- a/src/packages/generated/sql.gleam
+++ b/src/packages/generated/sql.gleam
@@ -96,7 +96,7 @@ pub fn get_package(
   name
 , description
 , docs_url
-, repository_url
+, links
 , inserted_in_hex_at
 , updated_in_hex_at
 from
@@ -134,7 +134,7 @@ pub fn search_packages(
   packages.name
 , description
 , docs_url
-, repository_url
+, links
 , array_agg(latest_releases.version) as latest_releases
 , packages.updated_in_hex_at
 from
@@ -313,7 +313,7 @@ insert into packages
   ( name
   , description
   , docs_url
-  , repository_url
+  , links
   , inserted_in_hex_at
   , updated_in_hex_at
   )
@@ -330,7 +330,7 @@ set
   updated_in_hex_at = excluded.updated_in_hex_at
 , description = excluded.description
 , docs_url = excluded.docs_url
-, repository_url = excluded.repository_url
+, links = excluded.links
 returning
   id
 "

--- a/src/packages/generated/sql.gleam
+++ b/src/packages/generated/sql.gleam
@@ -273,6 +273,10 @@ insert into hidden_packages values
 , ('sequin')
 on conflict do nothing;
 
+alter table packages
+add column if not exists docs_url text,
+add column if not exists repository_url text;
+
 end
 $$;
 "
@@ -304,6 +308,7 @@ pub fn upsert_package(
 insert into packages
   ( name
   , description
+  , docs_url
   , inserted_in_hex_at
   , updated_in_hex_at
   )
@@ -312,11 +317,13 @@ values
   , $2
   , $3
   , $4
+  , $5
   )
 on conflict (name) do update
 set
   updated_in_hex_at = excluded.updated_in_hex_at
 , description = excluded.description
+, docs_url = excluded.docs_url
 returning
   id
 "

--- a/src/packages/generated/sql.gleam
+++ b/src/packages/generated/sql.gleam
@@ -95,6 +95,7 @@ pub fn get_package(
     "select
   name
 , description
+, docs_url
 , inserted_in_hex_at
 , updated_in_hex_at
 from
@@ -131,6 +132,7 @@ pub fn search_packages(
     "select
   packages.name
 , description
+, docs_url
 , array_agg(latest_releases.version) as latest_releases
 , packages.updated_in_hex_at
 from
@@ -201,6 +203,11 @@ create table if not exists most_recent_hex_timestamp (
   -- now this table can only hold one row.
 , constraint most_recent_hex_timestamp_singleton check (id)
 );
+
+-- Use the timestamp of the first ever Gleam package as the initial timestamp.
+-- insert into most_recent_hex_timestamp
+-- values (1635092380)
+-- on conflict do nothing;
 
 create table if not exists packages
 ( id serial primary key

--- a/src/packages/index.gleam
+++ b/src/packages/index.gleam
@@ -1,10 +1,10 @@
 import birl/time.{DateTime}
 import gleam/dynamic.{DecodeError, Dynamic} as dyn
 import gleam/dynamic_extra as dyn_extra
-import gleam/map.{Map}
 import gleam/hexpm
 import gleam/json
 import gleam/list
+import gleam/map.{Map}
 import gleam/option.{None, Option, Some}
 import gleam/pgo
 import gleam/result.{try}

--- a/src/packages/index.gleam
+++ b/src/packages/index.gleam
@@ -210,7 +210,9 @@ fn decode_package_links(
   use json_data <- try(dyn.string(data))
 
   json.decode(json_data, using: dyn.map(of: dyn.string, to: dyn.string))
-  |> result.map_error(fn(error) { todo })
+  |> result.map_error(fn(_) {
+    [DecodeError(expected: "Map(String, String)", found: json_data, path: [])]
+  })
 }
 
 fn decode_package_summary(

--- a/src/packages/index.gleam
+++ b/src/packages/index.gleam
@@ -94,18 +94,22 @@ pub type Package {
   Package(
     name: String,
     description: Option(String),
+    docs_url: Option(String),
+    repository_url: Option(String),
     inserted_in_hex_at: DateTime,
     updated_in_hex_at: DateTime,
   )
 }
 
 pub fn decode_package(data: Dynamic) -> Result(Package, List(DecodeError)) {
-  dyn.decode4(
+  dyn.decode6(
     Package,
     dyn.element(0, dyn.string),
     dyn.element(1, dyn.optional(dyn.string)),
-    dyn.element(2, dyn_extra.unix_timestamp),
-    dyn.element(3, dyn_extra.unix_timestamp),
+    dyn.element(2, dyn.optional(dyn.string)),
+    dyn.element(3, dyn.optional(dyn.string)),
+    dyn.element(4, dyn_extra.unix_timestamp),
+    dyn.element(5, dyn_extra.unix_timestamp),
   )(data)
 }
 

--- a/src/packages/index.gleam
+++ b/src/packages/index.gleam
@@ -73,6 +73,7 @@ pub fn upsert_package(
   let parameters = [
     pgo.text(package.name),
     pgo.nullable(pgo.text, package.meta.description),
+    pgo.nullable(pgo.text, package.docs_html_url),
     pgo.int(time.to_unix(package.inserted_at)),
     pgo.int(time.to_unix(package.updated_at)),
   ]

--- a/src/packages/index.gleam
+++ b/src/packages/index.gleam
@@ -179,6 +179,7 @@ pub type PackageSummary {
   PackageSummary(
     name: String,
     description: String,
+    docs_url: Option(String),
     latest_versions: List(String),
     updated_in_hex_at: DateTime,
   )
@@ -187,12 +188,13 @@ pub type PackageSummary {
 fn decode_package_summary(
   data: Dynamic,
 ) -> Result(PackageSummary, List(DecodeError)) {
-  dyn.decode4(
+  dyn.decode5(
     PackageSummary,
     dyn.element(0, dyn.string),
     dyn.element(1, dyn.string),
-    dyn.element(2, dyn.list(dyn.string)),
-    dyn.element(3, dyn_extra.unix_timestamp),
+    dyn.element(2, dyn.optional(dyn.string)),
+    dyn.element(3, dyn.list(dyn.string)),
+    dyn.element(4, dyn_extra.unix_timestamp),
   )(data)
 }
 

--- a/src/packages/web/page.gleam
+++ b/src/packages/web/page.gleam
@@ -89,7 +89,17 @@ fn package_list_item(package: PackageSummary) -> Node(t) {
       html.p_text([], package.description),
       case links {
         [] -> html.Nothing
-        links -> html.div([attrs.class("package-links")], links)
+        links ->
+          html.nav(
+            [attrs.class("package-links")],
+            [
+              html.ul(
+                [],
+                links
+                |> list.map(fn(link) { html.li([], [link]) }),
+              ),
+            ],
+          )
       },
     ],
   )

--- a/src/packages/web/page.gleam
+++ b/src/packages/web/page.gleam
@@ -88,7 +88,7 @@ fn package_list_item(package: PackageSummary) -> Node(t) {
       html.h2([], [external_link_text(url, package.name)]),
       html.p_text([], package.description),
       case links {
-        [] -> html.span([], [])
+        [] -> html.Nothing
         links -> html.div([attrs.class("package-links")], links)
       },
     ],

--- a/src/packages/web/page.gleam
+++ b/src/packages/web/page.gleam
@@ -73,7 +73,7 @@ fn package_list_item(package: PackageSummary) -> Node(t) {
     [
       package.docs_url
       |> option.map(external_link_text(_, "Documentation")),
-      package.docs_url
+      package.repository_url
       |> option.map(external_link_text(_, "Repository")),
     ]
     |> list.filter_map(option.to_result(_, Nil))

--- a/src/packages/web/page.gleam
+++ b/src/packages/web/page.gleam
@@ -89,14 +89,7 @@ fn package_list_item(package: PackageSummary) -> Node(t) {
       html.p_text([], package.description),
       case links {
         [] -> html.span([], [])
-        links ->
-          html.div(
-            [attrs.class("package-links")],
-            links
-            |> list.map(fn(link) {
-              html.span([attrs.style("margin-right: var(--gap);")], [link])
-            }),
-          )
+        links -> html.div([attrs.class("package-links")], links)
       },
     ],
   )

--- a/src/packages/web/page.gleam
+++ b/src/packages/web/page.gleam
@@ -6,6 +6,7 @@ import nakai/html.{Node}
 import nakai/html/attrs
 import packages/index.{PackageSummary}
 import gleam/string
+import gleam/option
 
 pub fn packages_list(
   packages: List(PackageSummary),
@@ -65,6 +66,16 @@ fn package_list(packages: List(PackageSummary), search_term: String) -> Node(t) 
 
 fn package_list_item(package: PackageSummary) -> Node(t) {
   let url = "https://hex.pm/packages/" <> package.name
+
+  let links =
+    [
+      package.docs_url
+      |> option.map(external_link_text(_, "Documentation")),
+      package.docs_url
+      |> option.map(external_link_text(_, "Repository")),
+    ]
+    |> list.filter_map(option.to_result(_, Nil))
+
   html.li(
     [],
     [
@@ -74,6 +85,17 @@ fn package_list_item(package: PackageSummary) -> Node(t) {
       ),
       html.h2([], [external_link_text(url, package.name)]),
       html.p_text([], package.description),
+      case links {
+        [] -> html.span([], [])
+        links ->
+          html.div(
+            [attrs.class("package-links")],
+            links
+            |> list.map(fn(link) {
+              html.span([attrs.style("margin-right: var(--gap);")], [link])
+            }),
+          )
+      },
     ],
   )
 }

--- a/src/packages/web/page.gleam
+++ b/src/packages/web/page.gleam
@@ -2,12 +2,12 @@ import birl/time.{DateTime}
 import gleam/bit_builder.{BitBuilder}
 import gleam/list
 import gleam/map
+import gleam/option
 import nakai
 import nakai/html.{Node}
 import nakai/html/attrs
 import packages/index.{PackageSummary}
 import gleam/string
-import gleam/option
 
 pub fn packages_list(
   packages: List(PackageSummary),

--- a/src/packages/web/page.gleam
+++ b/src/packages/web/page.gleam
@@ -92,7 +92,7 @@ fn package_list_item(package: PackageSummary) -> Node(t) {
         format_date(package.updated_in_hex_at),
       ),
       html.h2([], [external_link_text(url, package.name)]),
-      html.p_text([], package.description),
+      html.p_text([attrs.class("package-description")], package.description),
       case links {
         [] -> html.Nothing
         links ->

--- a/src/packages/web/page.gleam
+++ b/src/packages/web/page.gleam
@@ -1,6 +1,7 @@
 import birl/time.{DateTime}
 import gleam/bit_builder.{BitBuilder}
 import gleam/list
+import gleam/map
 import nakai
 import nakai/html.{Node}
 import nakai/html/attrs
@@ -69,11 +70,16 @@ fn package_list(packages: List(PackageSummary), search_term: String) -> Node(t) 
 fn package_list_item(package: PackageSummary) -> Node(t) {
   let url = "https://hex.pm/packages/" <> package.name
 
+  let repository_url =
+    package.links
+    |> map.get("Repository")
+    |> option.from_result
+
   let links =
     [
       package.docs_url
       |> option.map(external_link_text(_, "Documentation")),
-      package.repository_url
+      repository_url
       |> option.map(external_link_text(_, "Repository")),
     ]
     |> list.filter_map(option.to_result(_, Nil))

--- a/test/packages/index_test.gleam
+++ b/test/packages/index_test.gleam
@@ -37,7 +37,10 @@ pub fn insert_package_test() {
         meta: hexpm.PackageMeta(
           description: Some("Standard library for Gleam"),
           licenses: ["Apache-2.0"],
-          links: map.new(),
+          links: map.from_list([
+            #("Website", "https://gleam.run/"),
+            #("Repository", "https://github.com/gleam-lang/stdlib"),
+          ]),
         ),
         name: "gleam_stdlib",
         owners: None,
@@ -53,7 +56,10 @@ pub fn insert_package_test() {
     description: Some("Standard library for Gleam"),
     name: "gleam_stdlib",
     docs_url: Some("https://hexdocs.pm/gleam_stdlib/"),
-    repository_url: None,
+    links: map.from_list([
+      #("Website", "https://gleam.run/"),
+      #("Repository", "https://github.com/gleam-lang/stdlib"),
+    ]),
     inserted_in_hex_at: time.from_unix(100),
     updated_in_hex_at: time.from_unix(2000),
   ))

--- a/test/packages/index_test.gleam
+++ b/test/packages/index_test.gleam
@@ -52,6 +52,8 @@ pub fn insert_package_test() {
   |> should.equal(Package(
     description: Some("Standard library for Gleam"),
     name: "gleam_stdlib",
+    docs_url: Some("https://hexdocs.pm/gleam_stdlib/"),
+    repository_url: None,
     inserted_in_hex_at: time.from_unix(100),
     updated_in_hex_at: time.from_unix(2000),
   ))


### PR DESCRIPTION
This PR adds "Documentation" and "Repository" links to the package entries.

This allows quickly accessing these links instead of having to hop through the Hex interface to get to them.

Here's what it looks like:

<img width="1232" alt="Screenshot 2023-05-29 at 3 40 10 PM" src="https://github.com/gleam-lang/packages/assets/1486634/493a34d9-fd1a-4cd8-b513-f331de2885c0">

If any of the links are missing for a package they will not be shown.
