### PR TITLE
Add support for loading environment variables from `.env` file

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -27,7 +27,7 @@ gleam_http = "~> 3.1"
 nakai = "~> 0.4"
 gleam_otp = "~> 0.5"
 gleam_hexpm = "~> 0.1"
+glenvy = "~> 0.1"
 
 [dev-dependencies]
 gleeunit = "~> 0.7"
-glenvy = "~> 0.1"

--- a/gleam.toml
+++ b/gleam.toml
@@ -30,3 +30,4 @@ gleam_hexpm = "~> 0.1"
 
 [dev-dependencies]
 gleeunit = "~> 0.7"
+glenvy = "~> 0.1"

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,24 +3,25 @@
 
 packages = [
   { name = "backoff", version = "1.1.6", build_tools = ["rebar3"], requirements = [], otp_app = "backoff", source = "hex", outer_checksum = "CF0CFFF8995FB20562F822E5CC47D8CCF664C5ECDC26A684CBE85C225F9D7C39" },
-  { name = "birl", version = "0.12.1", build_tools = ["gleam"], requirements = ["ranger", "gleam_stdlib"], otp_app = "birl", source = "hex", outer_checksum = "E03382B27CF89AF83AE4585C15D1479C80E1869BE518D54EF95959F7232084D7" },
+  { name = "birl", version = "0.12.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "ranger"], otp_app = "birl", source = "hex", outer_checksum = "E03382B27CF89AF83AE4585C15D1479C80E1869BE518D54EF95959F7232084D7" },
   { name = "certifi", version = "2.9.0", build_tools = ["rebar3"], requirements = [], otp_app = "certifi", source = "hex", outer_checksum = "266DA46BDB06D6C6D35FDE799BCB28D36D985D424AD7C08B5BB48F5B5CDD4641" },
   { name = "gleam_erlang", version = "0.19.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "720D1E0A0CEBBD51C4AA88501D1D4FBFEF4AA7B3332C994691ED944767A52582" },
-  { name = "gleam_hackney", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "hackney", "gleam_http"], otp_app = "gleam_hackney", source = "hex", outer_checksum = "B3C1E6BD138D57252F9F9E499C741E9227EE7EE9B017CA650EC8193E02F734E1" },
-  { name = "gleam_hexpm", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "birl"], otp_app = "gleam_hexpm", source = "hex", outer_checksum = "0F1080C3DCB8E69D844CB6127118C82D5EED1C3906F8F9F1DFF089FC8AC286C7" },
+  { name = "gleam_hackney", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_http", "gleam_stdlib", "hackney"], otp_app = "gleam_hackney", source = "hex", outer_checksum = "B3C1E6BD138D57252F9F9E499C741E9227EE7EE9B017CA650EC8193E02F734E1" },
+  { name = "gleam_hexpm", version = "0.1.0", build_tools = ["gleam"], requirements = ["birl", "gleam_stdlib"], otp_app = "gleam_hexpm", source = "hex", outer_checksum = "0F1080C3DCB8E69D844CB6127118C82D5EED1C3906F8F9F1DFF089FC8AC286C7" },
   { name = "gleam_http", version = "3.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "D034F5CE0639CD142CBA210B7D5D14236C284B0C5772A043D2E22128594573AE" },
-  { name = "gleam_json", version = "0.5.1", build_tools = ["gleam"], requirements = ["thoas", "gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "9A805C1E60FB9CD73AF3034EB464268A6B522D937FCD2DF92BD246F2F4B37930" },
+  { name = "gleam_json", version = "0.5.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "thoas"], otp_app = "gleam_json", source = "hex", outer_checksum = "9A805C1E60FB9CD73AF3034EB464268A6B522D937FCD2DF92BD246F2F4B37930" },
   { name = "gleam_otp", version = "0.5.3", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_erlang"], otp_app = "gleam_otp", source = "hex", outer_checksum = "6E705B69464237353E0380AC8143BDB29A3F0BF6168755D5F2D6E55A34A8B077" },
-  { name = "gleam_pgo", version = "0.4.1", build_tools = ["gleam"], requirements = ["pgo", "gleam_stdlib"], otp_app = "gleam_pgo", source = "hex", outer_checksum = "589DE52D0F61445133A0BE4C01C55989608F73918C22028B09353DE5AD9F7C83" },
-  { name = "gleam_stdlib", version = "0.28.2", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "088E334A00C9530D4B194F31406E51B6E4E4697C6A380D11591E60CC2F239724" },
+  { name = "gleam_pgo", version = "0.4.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "pgo"], otp_app = "gleam_pgo", source = "hex", outer_checksum = "589DE52D0F61445133A0BE4C01C55989608F73918C22028B09353DE5AD9F7C83" },
+  { name = "gleam_stdlib", version = "0.29.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "DB981FB670AAC6392C0694AF639C49ADF1C2E42664D5F90BBF573102667B8E53" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
-  { name = "glisten", version = "0.7.0", build_tools = ["gleam"], requirements = ["gleam_otp", "gleam_stdlib", "gleam_erlang"], otp_app = "glisten", source = "hex", outer_checksum = "52B530FF25370590843998D1B6C4EC6169DB1300D5E4407A5CDA1575374B7AEC" },
-  { name = "hackney", version = "1.18.1", build_tools = ["rebar3"], requirements = ["certifi", "metrics", "idna", "parse_trans", "mimerl", "ssl_verify_fun", "unicode_util_compat"], otp_app = "hackney", source = "hex", outer_checksum = "A4ECDAFF44297E9B5894AE499E9A070EA1888C84AFDD1FD9B7B2BC384950128E" },
+  { name = "glenvy", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "glenvy", source = "hex", outer_checksum = "50A87103940FA010778F4046156E57320C23E33E6E90C78B2A04915B713F6A12" },
+  { name = "glisten", version = "0.7.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "glisten", source = "hex", outer_checksum = "52B530FF25370590843998D1B6C4EC6169DB1300D5E4407A5CDA1575374B7AEC" },
+  { name = "hackney", version = "1.18.1", build_tools = ["rebar3"], requirements = ["mimerl", "metrics", "parse_trans", "ssl_verify_fun", "unicode_util_compat", "certifi", "idna"], otp_app = "hackney", source = "hex", outer_checksum = "A4ECDAFF44297E9B5894AE499E9A070EA1888C84AFDD1FD9B7B2BC384950128E" },
   { name = "idna", version = "6.1.1", build_tools = ["rebar3"], requirements = ["unicode_util_compat"], otp_app = "idna", source = "hex", outer_checksum = "92376EB7894412ED19AC475E4A86F7B413C1B9FBB5BD16DCCD57934157944CEA" },
   { name = "metrics", version = "1.0.1", build_tools = ["rebar3"], requirements = [], otp_app = "metrics", source = "hex", outer_checksum = "69B09ADDDC4F74A40716AE54D140F93BEB0FB8978D8636EADED0C31B6F099F16" },
   { name = "mimerl", version = "1.2.0", build_tools = ["rebar3"], requirements = [], otp_app = "mimerl", source = "hex", outer_checksum = "F278585650AA581986264638EBF698F8BB19DF297F66AD91B18910DFC6E19323" },
-  { name = "mist", version = "0.11.0", build_tools = ["gleam"], requirements = ["gleam_http", "gleam_erlang", "gleam_otp", "glisten", "gleam_stdlib"], otp_app = "mist", source = "hex", outer_checksum = "B990DB49BC7EA68B2BAFCE2C5A6A2F8469EEDEB29A406B182DC6389E14FFA10B" },
-  { name = "nakai", version = "0.7.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "nakai", source = "hex", outer_checksum = "F9A1B3AB4499430DDB0F33F4C8875B7C2B18F0D97DB4DC6C7B4BFF15B2882DB8" },
+  { name = "mist", version = "0.11.0", build_tools = ["gleam"], requirements = ["gleam_http", "gleam_otp", "gleam_stdlib", "gleam_erlang", "glisten"], otp_app = "mist", source = "hex", outer_checksum = "B990DB49BC7EA68B2BAFCE2C5A6A2F8469EEDEB29A406B182DC6389E14FFA10B" },
+  { name = "nakai", version = "0.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "nakai", source = "hex", outer_checksum = "E4BA604229121481776CB4DD42C6E5E7FB1A9BF303D7B1DCDFECFE5FA0B34382" },
   { name = "opentelemetry_api", version = "1.2.1", build_tools = ["rebar3", "mix"], requirements = ["opentelemetry_semantic_conventions"], otp_app = "opentelemetry_api", source = "hex", outer_checksum = "6D7A27B7CAD2AD69A09CABF6670514CAFCEC717C8441BEB5C96322BAC3D05350" },
   { name = "opentelemetry_semantic_conventions", version = "0.2.0", build_tools = ["rebar3", "mix"], requirements = [], otp_app = "opentelemetry_semantic_conventions", source = "hex", outer_checksum = "D61FA1F5639EE8668D74B527E6806E0503EFC55A42DB7B5F39939D84C07D6895" },
   { name = "parse_trans", version = "3.3.1", build_tools = ["rebar3"], requirements = [], otp_app = "parse_trans", source = "hex", outer_checksum = "07CD9577885F56362D414E8C4C4E6BDF10D43A8767ABB92D24CBE8B24C54888B" },
@@ -43,5 +44,6 @@ gleam_otp = "~> 0.5"
 gleam_pgo = "~> 0.4"
 gleam_stdlib = "~> 0.23"
 gleeunit = "~> 0.7"
+glenvy = "~> 0.1"
 mist = "~> 0.10"
 nakai = "~> 0.4"

--- a/src/packages.gleam
+++ b/src/packages.gleam
@@ -7,6 +7,7 @@ import gleam/list
 import gleam/otp/actor
 import gleam/otp/supervisor
 import gleam/string
+import glenvy/dotenv
 import mist
 import packages/index
 import packages/periodic
@@ -20,6 +21,8 @@ const usage = "Usage:
 "
 
 pub fn main() {
+  let _ = dotenv.load()
+
   case erlang.start_arguments() {
     ["list"] -> list()
     ["server"] -> server()


### PR DESCRIPTION
This PR adds support for loading environment variables from a `.env` file to improve local DX.

This is using my new Gleam package, [`glenvy`](https://hexdocs.pm/glenvy/) for loading the file.

### Motivation

When I first started hacking on `packages` I ran into some rather unhelpful error messages when trying to run `gleam run server` or `gleam run sync`:

```
exception error: #{function => <<"server">>,gleam_error => assert,line => 62,
                   message => <<"Assertion pattern match failed">>,
                   module => <<"packages">>,
                   value => {error,nil}}
  in function  packages:server/0 (/Users/maxdeviant/projects/gleam-packages/build/dev/erlang/packages/_gleam_artefacts/packages.erl, line 51)⏎ 
```

I eventually figured out that this was due to an assertion failing due to missing environment variables.

I've been using a local `justfile` (for [`just`](https://github.com/casey/just)) while working on `packages` as a way to source the environment variables from my `.env` file:

```just
set dotenv-load

test:
    gleam test

run:
    gleam run server

sync:
    gleam run sync
```

Of course, I figured it would be better if we could just support `.env` files out of the box 🙂 