### PR TITLE
Show latest version for packages

### DIFF
--- a/priv/styles.css
+++ b/priv/styles.css
@@ -125,12 +125,14 @@ h1, h2, h3, h4, h5, h6 {
 
 .package-name {
   display: inline-block;
-  margin: 0 var(--gap) var(--gap-s) 0;
+  margin: 0;
 }
 
 .package-latest-version {
   display: inline-block;
-  margin: 0 var(--gap) var(--gap-s) 0;
+  margin: 0;
+  margin-left: var(--gap);
+  color: var(--color-unexpected-aubergine);
 }
 
 .package-date-time {

--- a/priv/styles.css
+++ b/priv/styles.css
@@ -123,6 +123,16 @@ h1, h2, h3, h4, h5, h6 {
   margin-bottom: var(--gap-l);
 }
 
+.package-name {
+  display: inline-block;
+  margin: 0 var(--gap) var(--gap-s) 0;
+}
+
+.package-latest-version {
+  display: inline-block;
+  margin: 0 var(--gap) var(--gap-s) 0;
+}
+
 .package-date-time {
   float: right;
   color: var(--color-graphite);
@@ -152,8 +162,4 @@ h1, h2, h3, h4, h5, h6 {
   color: var(--color-unexpected-aubergine);
   font-size: var(--font-size-small);
   text-decoration: none;
-}
-
-.package-list h2 {
-  margin: 0 var(--gap) var(--gap-s) 0;
 }

--- a/src/packages/web/page.gleam
+++ b/src/packages/web/page.gleam
@@ -100,7 +100,7 @@ fn package_list_item(package: PackageSummary) -> Node(t) {
           ),
           case latest_version {
             Ok(latest_version) ->
-              html.h3_text(
+              html.div_text(
                 [attrs.class("package-latest-version")],
                 "v" <> latest_version,
               )

--- a/src/packages/web/page.gleam
+++ b/src/packages/web/page.gleam
@@ -70,6 +70,10 @@ fn package_list(packages: List(PackageSummary), search_term: String) -> Node(t) 
 fn package_list_item(package: PackageSummary) -> Node(t) {
   let url = "https://hex.pm/packages/" <> package.name
 
+  let latest_version =
+    package.latest_versions
+    |> list.first
+
   let repository_url =
     package.links
     |> map.get("Repository")
@@ -94,7 +98,7 @@ fn package_list_item(package: PackageSummary) -> Node(t) {
             [attrs.class("package-name")],
             [external_link_text(url, package.name)],
           ),
-          case list.first(package.latest_versions) {
+          case latest_version {
             Ok(latest_version) ->
               html.h3_text(
                 [attrs.class("package-latest-version")],

--- a/src/packages/web/page.gleam
+++ b/src/packages/web/page.gleam
@@ -87,11 +87,27 @@ fn package_list_item(package: PackageSummary) -> Node(t) {
   html.li(
     [],
     [
-      html.div_text(
-        [attrs.class("package-date-time")],
-        format_date(package.updated_in_hex_at),
+      html.div(
+        [],
+        [
+          html.h2(
+            [attrs.class("package-name")],
+            [external_link_text(url, package.name)],
+          ),
+          case list.first(package.latest_versions) {
+            Ok(latest_version) ->
+              html.h3_text(
+                [attrs.class("package-latest-version")],
+                "v" <> latest_version,
+              )
+            Error(Nil) -> html.Nothing
+          },
+          html.div_text(
+            [attrs.class("package-date-time")],
+            format_date(package.updated_in_hex_at),
+          ),
+        ],
       ),
-      html.h2([], [external_link_text(url, package.name)]),
       html.p_text([attrs.class("package-description")], package.description),
       case links {
         [] -> html.Nothing


### PR DESCRIPTION
This PR adds the latest version number next to the package name.

Here's what it looks like:

<img width="1381" alt="Screenshot 2023-05-31 at 7 47 13 PM" src="https://github.com/gleam-lang/packages/assets/1486634/bf50d323-7a78-448a-9b4a-3cbe2d3cc8f7">
