### PR TITLE
Add package counts

### DIFF
--- a/priv/styles.css
+++ b/priv/styles.css
@@ -106,6 +106,12 @@ h1, h2, h3, h4, h5, h6 {
   -webkit-appearance: none;
 }
 
+.site-subheader {
+  max-width: var(--content-width);
+  padding: var(--gap);
+  margin: 0 auto;
+}
+
 .site-footer {
   width: 100%;
   padding: var(--gap);

--- a/priv/styles.css
+++ b/priv/styles.css
@@ -106,12 +106,6 @@ h1, h2, h3, h4, h5, h6 {
   -webkit-appearance: none;
 }
 
-.site-subheader {
-  max-width: var(--content-width);
-  padding: var(--gap);
-  margin: 0 auto;
-}
-
 .site-footer {
   width: 100%;
   padding: var(--gap);
@@ -127,6 +121,10 @@ h1, h2, h3, h4, h5, h6 {
   list-style: none;
   margin-top: var(--gap);
   margin-bottom: var(--gap-l);
+}
+
+.package-list-message {
+  margin: 0;
 }
 
 .package-date-time {

--- a/sql/get_total_package_count.sql
+++ b/sql/get_total_package_count.sql
@@ -1,0 +1,4 @@
+select
+  count(1)
+from
+  packages;

--- a/src/packages/generated/sql.gleam
+++ b/src/packages/generated/sql.gleam
@@ -124,6 +124,21 @@ limit 1
   |> result.map_error(error.DatabaseError)
 }
 
+pub fn get_total_package_count(
+  db: pgo.Connection,
+  arguments: List(pgo.Value),
+  decoder: dynamic.Decoder(a),
+) -> QueryResult(a) {
+  let query =
+    "select
+  count(1)
+from
+  packages
+"
+  pgo.execute(query, db, arguments, decoder)
+  |> result.map_error(error.DatabaseError)
+}
+
 pub fn search_packages(
   db: pgo.Connection,
   arguments: List(pgo.Value),

--- a/src/packages/index.gleam
+++ b/src/packages/index.gleam
@@ -132,6 +132,16 @@ pub fn get_package(
   }
 }
 
+pub fn get_total_package_count(db: pgo.Connection) -> Result(Int, Error) {
+  use returned <- result.then(sql.get_total_package_count(
+    db,
+    [],
+    dyn.element(0, dyn.int),
+  ))
+  let assert [count] = returned.rows
+  Ok(count)
+}
+
 pub fn upsert_release(
   db: pgo.Connection,
   package_id: Int,

--- a/src/packages/web.gleam
+++ b/src/packages/web.gleam
@@ -56,8 +56,9 @@ fn javascript() -> Response(BitBuilder) {
 fn search(context: Context) -> Response(BitBuilder) {
   let search_term = get_search_parameter(context.request)
   let assert Ok(packages) = index.search_packages(context.db, search_term)
+  let assert Ok(total_package_count) = index.get_total_package_count(context.db)
 
-  let html = page.packages_list(packages, search_term)
+  let html = page.packages_list(packages, total_package_count, search_term)
   response.new(200)
   |> response.set_header("content-type", "text/html; charset=utf-8")
   |> response.set_body(html)

--- a/src/packages/web/page.gleam
+++ b/src/packages/web/page.gleam
@@ -74,7 +74,7 @@ fn search_aware_package_list(
     [], False ->
       html.p_text(
         [attrs.class("package-list-message")],
-        "I couldn't find any package matching your search: " <> search_term,
+        "I couldn't find any package matching your search.",
       )
     _, False -> {
       let package_count = list.length(packages)
@@ -88,8 +88,7 @@ fn search_aware_package_list(
               "I found",
               int.to_string(package_count),
               pluralize_package(package_count),
-              "matching your search:",
-              search_term,
+              "matching your search.",
             ]
             |> string.join(" "),
           ),

--- a/src/packages/web/page.gleam
+++ b/src/packages/web/page.gleam
@@ -81,9 +81,7 @@ fn package_list(packages: List(PackageSummary), search_term: String) -> Node(t) 
         "I couldn't find any package matching your search: " <> search_term,
       )
     _, False -> {
-      let package_count =
-        packages
-        |> list.length
+      let package_count = list.length(packages)
 
       html.div(
         [],
@@ -92,8 +90,7 @@ fn package_list(packages: List(PackageSummary), search_term: String) -> Node(t) 
             [],
             [
               "I found",
-              package_count
-              |> int.to_string,
+              int.to_string(package_count),
               pluralize_package(package_count),
               "matching your search:",
               search_term,

--- a/src/packages/web/page.gleam
+++ b/src/packages/web/page.gleam
@@ -1,5 +1,6 @@
 import birl/time.{DateTime}
 import gleam/bit_builder.{BitBuilder}
+import gleam/int
 import gleam/list
 import gleam/map
 import gleam/option
@@ -11,6 +12,7 @@ import gleam/string
 
 pub fn packages_list(
   packages: List(PackageSummary),
+  total_package_count: Int,
   search_term: String,
 ) -> BitBuilder {
   html.main(
@@ -28,12 +30,31 @@ pub fn packages_list(
           ),
         ],
       ),
+      html.div_text(
+        [attrs.class("site-subheader")],
+        [
+          "There are",
+          total_package_count
+          |> int.to_string,
+          pluralize_package(total_package_count),
+          "available ✨",
+        ]
+        |> string.join(" "),
+      ),
       html.div([attrs.class("content")], [package_list(packages, search_term)]),
     ],
   )
   |> layout
   |> nakai.to_string_builder
   |> bit_builder.from_string_builder
+}
+
+/// Pluralizes the word "package" based on the number we're referring to.
+fn pluralize_package(amount: Int) -> String {
+  case amount {
+    1 -> "package"
+    _ -> "packages"
+  }
 }
 
 fn search_form(search_term: String) -> Node(t) {
@@ -59,6 +80,33 @@ fn package_list(packages: List(PackageSummary), search_term: String) -> Node(t) 
         [],
         "I couldn't find any package matching your search: " <> search_term,
       )
+    _, False -> {
+      let package_count =
+        packages
+        |> list.length
+
+      html.div(
+        [],
+        [
+          html.p_text(
+            [],
+            [
+              "I found",
+              package_count
+              |> int.to_string,
+              pluralize_package(package_count),
+              "matching your search:",
+              search_term,
+            ]
+            |> string.join(" "),
+          ),
+          html.ul(
+            [attrs.class("package-list")],
+            list.map(packages, package_list_item),
+          ),
+        ],
+      )
+    }
     _, _ ->
       html.ul(
         [attrs.class("package-list")],

--- a/src/packages/web/page.gleam
+++ b/src/packages/web/page.gleam
@@ -30,31 +30,15 @@ pub fn packages_list(
           ),
         ],
       ),
-      html.div_text(
-        [attrs.class("site-subheader")],
-        [
-          "There are",
-          total_package_count
-          |> int.to_string,
-          pluralize_package(total_package_count),
-          "available ✨",
-        ]
-        |> string.join(" "),
+      html.div(
+        [attrs.class("content")],
+        [search_aware_package_list(packages, total_package_count, search_term)],
       ),
-      html.div([attrs.class("content")], [package_list(packages, search_term)]),
     ],
   )
   |> layout
   |> nakai.to_string_builder
   |> bit_builder.from_string_builder
-}
-
-/// Pluralizes the word "package" based on the number we're referring to.
-fn pluralize_package(amount: Int) -> String {
-  case amount {
-    1 -> "package"
-    _ -> "packages"
-  }
 }
 
 fn search_form(search_term: String) -> Node(t) {
@@ -73,11 +57,23 @@ fn search_form(search_term: String) -> Node(t) {
   )
 }
 
-fn package_list(packages: List(PackageSummary), search_term: String) -> Node(t) {
+/// Pluralizes the word "package" based on the number we're referring to.
+fn pluralize_package(amount: Int) -> String {
+  case amount {
+    1 -> "package"
+    _ -> "packages"
+  }
+}
+
+fn search_aware_package_list(
+  packages: List(PackageSummary),
+  total_package_count: Int,
+  search_term: String,
+) -> Node(t) {
   case packages, string.is_empty(search_term) {
     [], False ->
       html.p_text(
-        [],
+        [attrs.class("package-list-message")],
         "I couldn't find any package matching your search: " <> search_term,
       )
     _, False -> {
@@ -87,7 +83,7 @@ fn package_list(packages: List(PackageSummary), search_term: String) -> Node(t) 
         [],
         [
           html.p_text(
-            [],
+            [attrs.class("package-list-message")],
             [
               "I found",
               int.to_string(package_count),
@@ -97,19 +93,33 @@ fn package_list(packages: List(PackageSummary), search_term: String) -> Node(t) 
             ]
             |> string.join(" "),
           ),
-          html.ul(
-            [attrs.class("package-list")],
-            list.map(packages, package_list_item),
-          ),
+          package_list(packages),
         ],
       )
     }
     _, _ ->
-      html.ul(
-        [attrs.class("package-list")],
-        list.map(packages, package_list_item),
+      html.div(
+        [],
+        [
+          html.p_text(
+            [attrs.class("package-list-message")],
+            [
+              "There are",
+              total_package_count
+              |> int.to_string,
+              pluralize_package(total_package_count),
+              "available ✨",
+            ]
+            |> string.join(" "),
+          ),
+          package_list(packages),
+        ],
       )
   }
+}
+
+fn package_list(packages: List(PackageSummary)) -> Node(t) {
+  html.ul([attrs.class("package-list")], list.map(packages, package_list_item))
 }
 
 fn package_list_item(package: PackageSummary) -> Node(t) {


### PR DESCRIPTION
This PR adds package counts to the site.

### Total package count

There's now a banner at the top of the site showing the total number of packages that are indexed:

<img width="1338" alt="Screenshot 2023-05-31 at 11 44 43 AM" src="https://github.com/gleam-lang/packages/assets/1486634/abf44107-6dcf-4b78-a62c-bfa14ad711c5">

### Search results count

The search results now indicate how many packages were found matching the search:

<img width="1338" alt="Screenshot 2023-05-31 at 11 44 48 AM" src="https://github.com/gleam-lang/packages/assets/1486634/4e5d1824-aaee-45b9-8e6e-244e3746dc7b">

Feedback on the design is welcome!

Resolves #14.