### PR TITLE
Use the new v1 logo

### DIFF
--- a/priv/static/styles.css
+++ b/priv/static/styles.css
@@ -83,10 +83,11 @@ h6 {
   margin-bottom: var(--gap-s);
 }
 
-.site-header a img {
+.site-header .logo {
   display: inline-block;
-  height: 1.3em;
-  margin-right: 0.25em;
+  height: 2em;
+  transform: rotate(-10deg);
+  margin-right: 0.5em;
 }
 
 .site-header nav {

--- a/src/packages/web/page.gleam
+++ b/src/packages/web/page.gleam
@@ -23,7 +23,7 @@ pub fn packages_list(
         html.a([attribute.href("/")], [
           html.img([
             attribute.class("logo"),
-            attribute.src("https://gleam.run/images/lucy-charcoal-2.svg"),
+            attribute.src("https://gleam.run/images/lucy/lucy.svg"),
             attribute.alt("Lucy the star, Gleam's mascot"),
           ]),
           html.h1([], [element.text("Gleam Packages")]),
@@ -193,7 +193,7 @@ fn layout(content: Element(Nil)) -> Element(Nil) {
       ]),
       html.link([
         attribute.rel("icon"),
-        attribute.href("https://gleam.run/images/lucy-circle.svg"),
+        attribute.href("https://gleam.run/images/lucy/lucy.svg"),
       ]),
       html.script(
         [


### PR DESCRIPTION
I've changed the logo and favicon, added the signature -10deg tilt on the header bar and bumped up the logo size a little bit

![image](https://github.com/gleam-lang/packages/assets/4096683/c67b0696-f089-41f9-a94d-7d92f0b91cac)
