### PR TITLE
tweak: fix words overflow on small screens.

### DIFF
--- a/priv/static/styles.css
+++ b/priv/static/styles.css
@@ -264,6 +264,7 @@ html.theme-light .theme-button.-light {
 }
 
 .package-list .package-name {
+  overflow-wrap: break-word;
   margin: 0 var(--gap) var(--gap-s) 0;
 }
 


### PR DESCRIPTION
# before
![Screenshot_2024-03-17-02-08-22-26_4d38fce200f96aeac5e860e739312e76](https://github.com/gleam-lang/packages/assets/69188140/1891e6d2-0920-4b79-90db-a13c277df09d)
