### PR TITLE
Search if term is a substring of package name or description.

### DIFF
--- a/sql/search_packages.sql
+++ b/sql/search_packages.sql
@@ -10,6 +10,8 @@ from
 where
   (
     $1 = ''
+    or instr(lower(name), $2) > 0
+    or instr(lower(description), $2) > 0
     or id in (
       select rowid
       from packages_fts

--- a/sql/search_packages.sql
+++ b/sql/search_packages.sql
@@ -10,8 +10,8 @@ from
 where
   (
     $1 = ''
-    or instr(lower(name), $2) > 0
-    or instr(lower(description), $2) > 0
+    or instr(lower(name), lower($2)) > 0
+    or instr(lower(description), lower($2)) > 0
     or id in (
       select rowid
       from packages_fts

--- a/src/packages/generated/sql.gleam
+++ b/src/packages/generated/sql.gleam
@@ -137,6 +137,8 @@ from
 where
   (
     $1 = ''
+    or instr(lower(name), $2) > 0
+    or instr(lower(description), $2) > 0
     or id in (
       select rowid
       from packages_fts

--- a/src/packages/index.gleam
+++ b/src/packages/index.gleam
@@ -394,8 +394,7 @@ pub fn search_packages(
   let query = webquery_to_sqlite_fts_query(search_term)
   let params = [
     sqlight.text(query),
-    string.lowercase(search_term)
-      |> sqlight.text,
+    sqlight.text(search_term),
   ]
   let result = sql.search_packages(db, params, decode_package_summary)
   use packages <- result.try(result)

--- a/src/packages/index.gleam
+++ b/src/packages/index.gleam
@@ -392,7 +392,11 @@ pub fn search_packages(
 ) -> Result(List(PackageSummary), Error) {
   let db = db.inner
   let query = webquery_to_sqlite_fts_query(search_term)
-  let params = [sqlight.text(query)]
+  let params = [
+    sqlight.text(query),
+    string.lowercase(search_term)
+      |> sqlight.text,
+  ]
   let result = sql.search_packages(db, params, decode_package_summary)
   use packages <- result.try(result)
 

--- a/test/packages/index_test.gleam
+++ b/test/packages/index_test.gleam
@@ -352,3 +352,55 @@ pub fn search_packages_query_escaping_test() {
   packages
   |> should.equal([])
 }
+
+pub fn search_packages_substring_test() {
+  use db <- tests.with_database
+
+  let assert Ok(package_id) =
+    index.upsert_package(
+      db,
+      hexpm.Package(
+        downloads: dict.from_list([#("all", 5), #("recent", 2)]),
+        docs_html_url: Some("https://hexdocs.pm/gleam_pgo/"),
+        html_url: Some("https://hex.pm/packages/gleam_pgo"),
+        meta: hexpm.PackageMeta(
+          description: Some("Gleam bindings to the PGO PostgreSQL client"),
+          licenses: ["Apache-2.0"],
+          links: dict.from_list([
+            #("Website", "https://gleam.run/"),
+            #("Repository", "https://github.com/gleam-experiments/pgo"),
+          ]),
+        ),
+        name: "gleam_pgo",
+        owners: None,
+        releases: [],
+        inserted_at: birl.from_unix(100),
+        updated_at: birl.from_unix(2000),
+      ),
+    )
+
+  let assert Ok(_) =
+    index.upsert_release(
+      db,
+      package_id,
+      hexpm.Release(
+        version: "0.6.1",
+        checksum: "18a4940471ba798aa1fb85cd6e6d035a7403f66c4a2f19cdd471e0da450c3633",
+        url: "https://hex.pm/apik/packages/gleam_pgo/releases/0.6.1",
+        downloads: 0,
+        meta: hexpm.ReleaseMeta(app: Some("gleam_pgo"), build_tools: ["gleam"]),
+        publisher: Some(hexpm.PackageOwner(
+          username: "lpil",
+          email: None,
+          url: "https://hex.pm/users/lpil",
+        )),
+        retirement: None,
+        updated_at: birl.from_unix(1001),
+        inserted_at: birl.from_unix(2001),
+      ),
+    )
+
+  let assert Ok(packages) = index.search_packages(db, "sql")
+  list.length(packages)
+  |> should.equal(1)
+}


### PR DESCRIPTION
(Maybe) closes #22 
When searching for a package, before the FTS query, will check if the term is a substring of the package name or description.

---

The term is lowercased so that the search can be case insensitive ("SQL" and "sql" would yield different results otherwise). Rather than using the existing parameter and lowercasing in the query, uses a second parameter due to the `webquery_to_sqlite_fts_query` function manipulating the string.

---

Current
![image](https://github.com/gleam-lang/packages/assets/45527309/16cc31fd-6f17-437a-892f-f64ad9f8a57e)
After substring search
![image](https://github.com/gleam-lang/packages/assets/45527309/11ee5afa-2536-4097-86c4-50d199d1fa22)