### PR TITLE
Fix layout shifts

### DIFF
--- a/src/packages/web/page.gleam
+++ b/src/packages/web/page.gleam
@@ -182,6 +182,13 @@ fn layout(content: Element(Nil)) -> StringTree {
       ]),
       html.title([], "Gleam Packages"),
       html.link([
+        attribute.rel("preload"),
+        attribute.href("/fonts/Lexend.woff2"),
+        attribute.type_("font/woff2"),
+        attribute("crossorigin", "true"),
+        attribute("as", "font"),
+      ]),
+      html.link([
         attribute.rel("stylesheet"),
         attribute.href("/static/styles.css"),
       ]),

--- a/src/packages/web/page.gleam
+++ b/src/packages/web/page.gleam
@@ -217,6 +217,8 @@ fn navbar() {
     html.div([class("container")], [
       html.a([attribute.href("/"), class("nav-brand")], [
         html.img([
+          attribute.width(55),
+          attribute.height(60),
           attribute.src("/static/packages-icon.svg"),
           attribute.alt("The Gleam Packages icon, Lucy popping out of a box!"),
         ]),


### PR DESCRIPTION
On first load there is some logo / font jank that is making layout shift that I attempted to fix (not completely) but decently.

Here is recording of doing CMD + Shift + R

https://github.com/user-attachments/assets/a4c0ed87-30e4-4315-bcc4-ffab18f93ca4

