### PR TITLE
Hide zero ver packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,14 +9,14 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    
+
     steps:
       - uses: actions/checkout@v3
       - uses: erlef/setup-beam@v1
         with:
           # Be sure to change in the dockerfile also
           otp-version: "28.0.2.0"
-          gleam-version: "1.15.2"
+          gleam-version: "1.16.0"
           rebar3-version: "3"
       - run: gleam test
       - run: gleam format --check src test
@@ -50,8 +50,8 @@ jobs:
           docker push $TAG
 
       - uses: actions/delete-package-versions@v5
-        with: 
-          package-name: 'packages'
-          package-type: 'container'
+        with:
+          package-name: "packages"
+          package-type: "container"
           min-versions-to-keep: 10
-          delete-only-untagged-versions: 'true'
+          delete-only-untagged-versions: "true"

--- a/src/packages/storage.gleam
+++ b/src/packages/storage.gleam
@@ -481,11 +481,10 @@ pub fn search_packages(
   search_term: String,
 ) -> Result(SearchOutcome, Error) {
   use found <- result.try(text_search.lookup(search, search_term))
+  use results <- result.try(rank_found_results(found, db, search_term))
 
-  case found {
-    [_, ..] ->
-      rank_found_results(found, db, search_term)
-      |> result.map(Packages)
+  case results {
+    [_, ..] -> Ok(Packages(results))
 
     // If no results are found we try and suggest a fix for the search term.
     [] ->
@@ -498,6 +497,7 @@ pub fn search_packages(
 
 /// Given a list of `text_search` results, this returns a list of the matching
 /// packages, ranked from most relevant to least relevant.
+/// Any v0.x.y package is going to be excluded from the final result.
 ///
 fn rank_found_results(
   found: List(text_search.Found),
@@ -514,7 +514,22 @@ fn rank_found_results(
 
   packages
   |> list.sort(fn(a, b) { list_compare(b.0, a.0, int.compare) })
-  |> list.map(fn(pair) { pair.1 })
+  |> list.filter_map(fn(pair) {
+    let #(_sorting_key, package) = pair
+    case is_zero_ver(package) {
+      True -> Error(Nil)
+      False -> Ok(package)
+    }
+  })
+}
+
+/// Returns `True` if the package's latest version has 0 as its major version
+/// number.
+fn is_zero_ver(package: Package) -> Bool {
+  case package.latest_version {
+    "0." <> _ -> True
+    _ -> False
+  }
 }
 
 /// This is the value we use to determine what order packages should be shown
@@ -751,7 +766,9 @@ fn timestamp_to_date_string(timestamp: Timestamp) -> String {
   |> string.slice(0, 10)
 }
 
-pub fn packages_most_recent_first(db: Database) -> Result(List(Package), Error) {
+pub fn packages_most_recent_first(
+  db: Database,
+) -> Result(List(Package), Error) {
   use packages <- result.try(list_packages(db))
   use packages <- result.map(list.try_map(packages, get_package(db, _)))
   list.sort(packages, fn(a, b) {

--- a/src/packages/text_search.gleam
+++ b/src/packages/text_search.gleam
@@ -235,7 +235,10 @@ pub fn did_you_mean(
 /// Finds the closest word amongst `words`. If none of the possible words is
 /// close enough then this returns `Error(Nil)`.
 ///
-fn closest_word(to word: String, from words: Set(String)) -> Result(String, Nil) {
+fn closest_word(
+  to word: String,
+  from words: Set(String),
+) -> Result(String, Nil) {
   // We want to limit the maximum edit distance. Otherwise we could end up
   // suggesting fixes that are not related at all to the original query.
   let word_length = string.length(word)


### PR DESCRIPTION
Hello! Now that sodlib is v1 I think the package site should stop showing v0.x.y packages, making it harder to publish and depend on packages that can introduce breaking changes at any time.

I couldn't find any tests for the function that I changed, should we try and write some?