### PR TITLE
Fix year_internet_points date range boundary

### DIFF
--- a/src/packages/storage.gleam
+++ b/src/packages/storage.gleam
@@ -615,7 +615,7 @@ pub fn year_internet_points(
   let start = watermark(year)
   let end = watermark(year + 1)
   let this_period = fn(time) {
-    timestamp.compare(start, time) != order.Lt
+    timestamp.compare(start, time) != order.Gt
     && timestamp.compare(time, end) == order.Lt
   }
 

--- a/test/packages/storage_test.gleam
+++ b/test/packages/storage_test.gleam
@@ -188,6 +188,73 @@ pub fn insert_ignored_package_test() {
     == Error(error.StorageError(storail.ObjectNotFound([], "gleam_file")))
 }
 
+fn insert_package_at(db, name, inserted_at) {
+  let assert Ok(_) =
+    storage.upsert_package_from_hex(
+      db,
+      hexpm.Package(
+        downloads: dict.new(),
+        docs_html_url: None,
+        html_url: None,
+        meta: hexpm.PackageMeta(
+          description: Some("x"),
+          licenses: [],
+          links: dict.new(),
+        ),
+        name: name,
+        owners: None,
+        releases: [],
+        inserted_at: inserted_at,
+        updated_at: inserted_at,
+      ),
+      timestamp.from_unix_seconds(0),
+      "1.0.0",
+    )
+}
+
+pub fn year_internet_points_counts_only_that_year_test() {
+  use db <- tests.with_database
+  let at = fn(date) {
+    timestamp.from_calendar(
+      date,
+      calendar.TimeOfDay(12, 0, 0, 0),
+      calendar.utc_offset,
+    )
+  }
+
+  let _ =
+    insert_package_at(
+      db,
+      "in_year_a",
+      at(calendar.Date(2025, calendar.March, 15)),
+    )
+  let _ =
+    insert_package_at(
+      db,
+      "in_year_b",
+      at(calendar.Date(2025, calendar.September, 15)),
+    )
+  let _ =
+    insert_package_at(
+      db,
+      "prior_year",
+      at(calendar.Date(2024, calendar.June, 15)),
+    )
+  let _ =
+    insert_package_at(
+      db,
+      "next_year",
+      at(calendar.Date(2026, calendar.June, 15)),
+    )
+
+  let assert Ok(points2024) = storage.year_internet_points(db, 2024)
+  assert points2024.new_packages == 1
+  let assert Ok(points2025) = storage.year_internet_points(db, 2025)
+  assert points2025.new_packages == 2
+  let assert Ok(points2026) = storage.year_internet_points(db, 2026)
+  assert points2026.new_packages == 1
+}
+
 pub fn insert_release_test() {
   use db <- tests.with_database
   let now = timestamp.from_unix_seconds(3000)


### PR DESCRIPTION
I was looking at the internet points pages by year, and it seemed weird.

The `this_period` predicate inverted the start comparison, so it matched `time <= start of year` instead of `start <= time < end`. It counted everything up to Jan 1 rather than events in the year.